### PR TITLE
Fix: Resolve ruff linting errors causing CI failure

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -8,11 +8,10 @@ import argparse
 import csv
 import json
 import sys
-import time
 import urllib.request
 import urllib.error
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 
 # Weather code mapping (WMO codes to readable conditions)
@@ -157,7 +156,7 @@ def save_to_csv(data: Dict, location: str, lat: float, lon: float, filename: str
     # Check if file exists to determine if we need to write header
     file_exists = False
     try:
-        with open(filename, 'r') as f:
+        with open(filename, 'r') as _:
             file_exists = True
     except FileNotFoundError:
         pass


### PR DESCRIPTION
This PR fixes the ruff linting errors that were causing the CI workflow to fail.

## Changes

- Removed unused `import time`
- Removed unused `List` from typing imports
- Fixed unused variable `f` by renaming to `_` in the file existence check

## Verification

These changes address all 3 ruff errors:
1. `F401` - `time` imported but unused
2. `F401` - `typing.List` imported but unused  
3. `F841` - Local variable `f` assigned but never used

The CI workflow should now pass.