### PR TITLE
Fix: Handle generic Exception in fetch_weather_data

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -123,7 +123,7 @@ def fetch_weather_data(lat: float, lon: float, timeout: int = 10) -> Optional[Di
             'conditions': condition
         }
         
-    except (urllib.error.URLError, json.JSONDecodeError, KeyError) as e:
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError, Exception) as e:
         print(f"Error fetching weather data for coordinates ({lat}, {lon}): {e}", file=sys.stderr)
         return None
 


### PR DESCRIPTION
This PR fixes the failing test `test_fetch_weather_data_failure`.

## Problem

The test mocks `urllib.request.urlopen` to raise a generic `Exception(`Connection error`)`, but `fetch_weather_data` only caught specific exception types:
- `urllib.error.URLError`
- `json.JSONDecodeError`
- `KeyError`

This caused the test to fail with an unhandled exception.

## Fix

Added `Exception` to the caught exception types in `fetch_weather_data`. This ensures the function returns `None` as expected when any error occurs during the API call.

## Verification

Once merged, the CI workflow should pass all tests.